### PR TITLE
Generic model infrastructure + tracking tests

### DIFF
--- a/src/napari_deeplabcut/_tests/conftest.py
+++ b/src/napari_deeplabcut/_tests/conftest.py
@@ -7,6 +7,13 @@ import pytest
 from skimage.io import imsave
 
 from napari_deeplabcut import _writer, keypoints
+from napari_deeplabcut.tracking._data import (
+    RawModelOutputs,
+    TrackingModelInputs,
+    TrackingWorkerData,
+    TrackingWorkerOutput,
+)
+from napari_deeplabcut.tracking._models import AVAILABLE_TRACKERS, TrackingModel
 
 os.environ["NAPARI_DLC_HIDE_TUTORIAL"] = "True"
 os.environ["NAPARI_ASYNC"] = "0"  # avoid async teardown surprises in tests
@@ -143,3 +150,127 @@ def video_path(tmp_path_factory):
         writer.write(frame)
     writer.release()
     return output_path
+
+
+# --- Tracking fixtures ---
+DUMMY_TRACKER_NAME = "TestTracker"
+
+
+class DummyTracker(TrackingModel):
+    """
+    Minimal tracker that:
+    - echoes inputs to outputs with a tiny deterministic transform,
+    - emits progress via the callback,
+    - honors stop_callback.
+    """
+
+    name = DUMMY_TRACKER_NAME
+    info_text = "Dummy tracker for unit testing."
+
+    def load_model(self, device: str):
+        # No-op model; keep a simple config to emulate 'step' like CoTracker.
+        class _NoOpModel:
+            step = 3
+
+        return _NoOpModel()
+
+    def prepare_inputs(self, cfg: "TrackingWorkerData", **kwargs) -> TrackingModelInputs:
+        # Ensure video is (T, H, W, C) and keypoints is (K, 3) where columns: [frame_idx, x, y] or [id, x, y]
+        video = np.asarray(cfg.video)
+        queries = np.asarray(cfg.keypoints).copy()
+        metadata = {
+            "keypoint_range": cfg.keypoint_range,
+            "backward_tracking": getattr(cfg, "backward_tracking", False),
+        }
+        return TrackingModelInputs(video=video, keypoints=queries, metadata=metadata)
+
+    def run(self, inputs: TrackingModelInputs, progress_callback, stop_callback, **kwargs) -> RawModelOutputs:
+        # Fake progression per frame; stop if requested.
+        T = inputs.video.shape[0]
+        K = inputs.keypoints.shape[0]
+
+        # Produce tracks of shape (T, K, 2) with a deterministic offset (e.g., +1 pixel)
+        tracks = np.zeros((T, K, 2), dtype=float)
+        for t in range(T):
+            progress_callback(t, T)
+            if stop_callback():
+                # Return partial result up to t
+                tracks = tracks[: t + 1]
+                vis = np.ones_like(tracks[..., 0], dtype=bool)  # visibility dummy
+                return RawModelOutputs(keypoints=tracks, keypoint_features={"visibility": vis})
+            # Use the input (x, y) for all K points and add a tiny drift proportional to t
+            tracks[t, :, 0] = inputs.keypoints[:, 1] + 0.1 * t  # x
+            tracks[t, :, 1] = inputs.keypoints[:, 2] + 0.1 * t  # y
+
+        vis = np.ones_like(tracks[..., 0], dtype=bool)
+        return RawModelOutputs(keypoints=tracks, keypoint_features={"visibility": vis})
+
+    def prepare_outputs(
+        self, model_outputs: RawModelOutputs, worker_inputs: "TrackingWorkerData" = None, **kwargs
+    ) -> "TrackingWorkerOutput":
+        # Flatten (T, K, 2) -> (N, 3) with [frame_idx, x, y]
+        tracks = model_outputs.keypoints
+        T = tracks.shape[0]
+        K = tracks.shape[1]
+
+        T1, T2 = worker_inputs.keypoint_range
+        frame_ids = np.repeat(np.arange(T1, T1 + T), K)
+        flat = tracks.reshape(-1, 2)
+        keypoints = np.column_stack((frame_ids, flat))  # (N, 3)
+
+        # Minimal features: concat original per-keypoint features replicated per frame
+        keypoints_features = pd.concat(
+            [worker_inputs.keypoint_features] * T,
+            ignore_index=True,
+        )
+
+        return TrackingWorkerOutput(
+            keypoints=keypoints,
+            keypoint_features=keypoints_features,
+        )
+
+
+@pytest.fixture(autouse=True)
+def register_dummy_tracker():
+    """
+    Auto-register DummyTracker for all tests and restore registry afterwards.
+    """
+    prev = dict(AVAILABLE_TRACKERS)
+    AVAILABLE_TRACKERS[DUMMY_TRACKER_NAME] = {"class": DummyTracker}
+    try:
+        yield
+    finally:
+        AVAILABLE_TRACKERS.clear()
+        AVAILABLE_TRACKERS.update(prev)
+
+
+@pytest.fixture
+def track_worker_inputs():
+    """
+    Provide minimal valid TrackingWorkerData with:
+    - 5-frame RGB video of 4x4 pixels,
+    - 2 keypoints,
+    - keypoint_range covering all frames,
+    - simple features DataFrame.
+    """
+    video = np.zeros((5, 4, 4, 3), dtype=np.uint8)
+
+    keypoints = np.array(
+        [
+            [0, 10.0, 20.0],
+            [1, 30.0, 40.0],
+        ],
+        dtype=float,
+    )
+
+    keypoint_features = pd.DataFrame({"id": [0, 1], "name": ["kp0", "kp1"]})
+
+    # Build TrackingWorkerData
+    return TrackingWorkerData(
+        tracker_name=DUMMY_TRACKER_NAME,
+        video=video,
+        keypoints=keypoints,
+        keypoint_range=(0, 5),  # frames 0..4
+        keypoint_features=keypoint_features,
+        backward_tracking=False,
+    )

--- a/src/napari_deeplabcut/_tests/tracking/test_widgets.py
+++ b/src/napari_deeplabcut/_tests/tracking/test_widgets.py
@@ -1,0 +1,197 @@
+import numpy as np
+import pandas as pd
+import pytest
+from qtpy.QtCore import Qt
+
+from napari_deeplabcut.tracking._data import TrackingWorkerData
+from napari_deeplabcut.tracking._models import AVAILABLE_TRACKERS
+
+_DUMMY_VIDEO_N_FRAMES = 10
+
+
+def _get_tracking_controls(viewer):
+    for title, dock in viewer.window.dock_widgets.items():
+        if "Tracking controls" in title and "napari-deeplabcut" in title:
+            return dock
+    raise RuntimeError("Tracking controls dock widget not found")
+
+
+@pytest.fixture
+def setup_tracking_widget(qtbot, viewer, monkeypatch):
+    """
+    Factory fixture that returns a function to set up the TrackingControls test environment.
+
+    Usage in tests:
+        tc, video_layer, points_layer = setup_tracking_env(add_data=True)
+        # or for just the widget:
+        tc = setup_tracking_env()
+    """
+
+    def _setup_tracking_data(*, add_data: bool = False, disable_insert_hooks: bool = True):
+        tc = _get_tracking_controls(viewer)
+        qtbot.addWidget(tc)
+
+        # Optionally disable plugin insert hooks that assume DLC metadata/header.
+        if add_data and disable_insert_hooks:
+            monkeypatch.setattr(
+                "napari_deeplabcut._widgets.KeypointControls.on_insert",
+                lambda *args, **kwargs: None,
+                raising=False,
+            )
+            monkeypatch.setattr(
+                "napari_deeplabcut._widgets.KeypointMatplotlibCanvas._load_dataframe",
+                lambda *args, **kwargs: None,
+                raising=False,
+            )
+
+        if add_data:
+            # Minimal, deterministic video and points layers
+            video_layer = viewer.add_image(np.zeros((_DUMMY_VIDEO_N_FRAMES, 4, 4), dtype=np.uint8), name="video_stack")
+            points_layer = viewer.add_points(
+                np.array([[0, 1.0, 2.0], [0, 3.0, 4.0]]),
+                features=pd.DataFrame({"id": [0, 1], "name": ["kp0", "kp1"]}),
+                name="keypoints",
+            )
+            tc._video_layer_combo.value = video_layer
+            tc._keypoint_layer_combo.value = points_layer
+            return tc, video_layer, points_layer
+
+        return tc
+
+    return _setup_tracking_data
+
+
+def test_tracking_controls_initial_state(setup_tracking_widget):
+    tc = setup_tracking_widget(add_data=False)
+
+    items = [tc._tracking_method_combo.itemText(i) for i in range(tc._tracking_method_combo.count())]
+    assert set(items) >= set(AVAILABLE_TRACKERS.keys())
+    current = tc._tracking_method_combo.currentText()
+    info = AVAILABLE_TRACKERS[current]["class"].info_text
+    assert tc._model_info_button.toolTip() == info
+
+
+def test_tracking_frame_controls_layer_selection_and_ranges(setup_tracking_widget, viewer):
+    tc, video_layer, points_layer = setup_tracking_widget(add_data=True)
+    viewer.dims.current_step = (2,) + (0,) * (viewer.dims.ndim - 1)
+    tc._video_layer_changed()
+    # Forward range
+    assert tc._forward_slider.minimum() == 0
+    assert tc._forward_slider.maximum() == _DUMMY_VIDEO_N_FRAMES - 1 - 2  # 2 steps forward possible
+    assert tc._forward_spinbox_absolute.minimum() == 2
+    assert tc._forward_spinbox_absolute.maximum() == _DUMMY_VIDEO_N_FRAMES - 1
+    # Backward range
+    assert tc._backward_slider.minimum() == -2
+    assert tc._backward_slider.maximum() == 0
+    assert tc._backward_spinbox_absolute.minimum() == 0
+    assert tc._backward_spinbox_absolute.maximum() == 2
+    # Reference spinbox
+    assert tc._reference_spinbox.value() == 2
+    assert tc._reference_spinbox.minimum() == 0
+    assert tc._reference_spinbox.maximum() == _DUMMY_VIDEO_N_FRAMES - 1
+
+    big_video_n_frames = 200
+    new_video = np.zeros((big_video_n_frames, 4, 4), dtype=np.uint8)
+    tc._video_layer_combo.value = viewer.add_image(new_video, name="big_video")
+    tc._video_layer_changed()
+    frame = 150
+    viewer.dims.current_step = (frame,) + (0,) * (viewer.dims.ndim - 1)
+    # Forward range
+    assert tc._forward_slider.minimum() == 0
+    assert tc._forward_slider.maximum() == big_video_n_frames - 1 - frame
+    assert tc._forward_spinbox_absolute.minimum() == frame
+    assert tc._forward_spinbox_absolute.maximum() == big_video_n_frames - 1
+    # Backward range
+    assert tc._backward_slider.minimum() == -frame
+    assert tc._backward_slider.maximum() == 0
+    assert tc._backward_spinbox_absolute.minimum() == 0
+    assert tc._backward_spinbox_absolute.maximum() == frame
+    # Reference spinbox
+    assert tc._reference_spinbox.value() == frame
+    assert tc._reference_spinbox.minimum() == 0
+    assert tc._reference_spinbox.maximum() == big_video_n_frames - 1
+
+
+def test_forward_track(setup_tracking_widget, qtbot, viewer):
+    tc, video_layer, points_layer = setup_tracking_widget(add_data=True)
+
+    # Only change internal state
+    def fake_start_worker(self):
+        self.worker_started = True
+
+    from types import MethodType
+
+    tc._start_worker = MethodType(fake_start_worker, tc)
+
+    # Set current frame to 0, set forward absolute to 3
+    viewer.dims.current_step = (0,) + (0,) * (viewer.dims.ndim - 1)
+    tc._video_layer_changed()
+    tc._reference_spinbox.setValue(0)
+    tc._forward_spinbox_absolute.setValue(3)
+
+    with qtbot.waitSignal(tc.trackingRequested, timeout=1500) as req:
+        qtbot.mouseClick(tc._tracking_forward_button, Qt.LeftButton)
+
+    twd: TrackingWorkerData = req.args[0]
+    assert isinstance(twd, TrackingWorkerData)
+    assert twd.tracker_name == tc._tracking_method_combo.currentText()
+    assert twd.backward_tracking is False
+    # video slice should have length 3 (frames 0..3 inclusive when +1 applied)
+    assert twd.video.shape[0] == 4  # because track_forward uses forward_frame_idx + 1
+    # keypoints should be those from ref frame with frame index reset to 0
+    assert (twd.keypoints[:, 0] == 0).all()
+    # features replicated per ref frame selection (only ref frame rows)
+    assert len(twd.keypoint_features) == len(points_layer.features)
+
+
+def test_backward_track(setup_tracking_widget, qtbot, viewer):
+    tc, video_layer, points_layer = setup_tracking_widget(add_data=True)
+    from types import MethodType
+
+    tc._start_worker = MethodType(lambda self: setattr(self, "worker_started", True), tc)
+
+    # Set ref frame to 2; backward absolute to 0 so it’s < ref
+    viewer.dims.current_step = (2,) + (0,) * (viewer.dims.ndim - 1)
+    tc._video_layer_changed()
+    tc._backward_spinbox_absolute.setValue(0)
+
+    with qtbot.waitSignal(tc.trackingRequested, timeout=1500) as req:
+        qtbot.mouseClick(tc._tracking_backward_button, Qt.LeftButton)
+    twd = req.args[0]
+    assert twd.backward_tracking is True
+    # For backward, track() reverses the video slice
+    assert twd.video.shape[0] == (2 - 0 + 1)  # inclusive range when +1 is applied in TrackControls
+
+
+def test_bothway_track(setup_tracking_widget, qtbot, viewer):
+    tc, video_layer, points_layer = setup_tracking_widget(add_data=True)
+    from types import MethodType
+
+    tc._start_worker = MethodType(lambda self: setattr(self, "worker_started", True), tc)
+
+    viewer.dims.current_step = (3,) + (0,) * (viewer.dims.ndim - 1)
+    tc._video_layer_changed()
+    tc._reference_spinbox.setValue(0)
+    tc._forward_spinbox_absolute.setValue(6)
+    tc._backward_spinbox_absolute.setValue(0)
+
+    captured = []
+    tc.trackingRequested.connect(lambda d: captured.append(d))
+    # Ensure backward path doesn't fail due to missing keypoint_widget
+    tc.keypoint_widget = object()
+
+    with qtbot.waitSignals([tc.trackingRequested, tc.trackingRequested], timeout=2000):
+        qtbot.mouseClick(tc._tracking_bothway_button, Qt.LeftButton)
+        tc.trackedKeypointsAdded.emit()
+    assert len(captured) == 2
+    assert captured[0].backward_tracking is False
+    assert captured[1].backward_tracking is True
+
+    # Do the same when forward == reference (should only do backward tracking)
+    captured.clear()
+    tc._forward_spinbox_absolute.setValue(0)
+    tc._video_layer_changed()
+    with qtbot.waitSignal(tc.trackingRequested, timeout=1500):
+        qtbot.mouseClick(tc._tracking_bothway_button, Qt.LeftButton)
+    assert len(captured) == 1
+    assert captured[0].backward_tracking is True

--- a/src/napari_deeplabcut/_tests/tracking/test_worker.py
+++ b/src/napari_deeplabcut/_tests/tracking/test_worker.py
@@ -1,0 +1,53 @@
+from napari_deeplabcut.tracking._data import TrackingWorkerOutput
+from napari_deeplabcut.tracking._worker import TrackingWorker
+
+
+def test_tracking_worker(qtbot, track_worker_inputs):
+    worker = TrackingWorker()
+
+    await_finished = qtbot.waitSignal(worker.trackingFinished, timeout=1000)
+    worker.track(track_worker_inputs)
+
+    output: TrackingWorkerOutput = await_finished.args[0]
+    assert isinstance(output, TrackingWorkerOutput)
+    # Expect (T * K, 3) with columns [frame_idx, x, y]
+    T = track_worker_inputs.video.shape[0]
+    K = track_worker_inputs.keypoints.shape[0]
+    assert output.keypoints.shape == (T * K, 3)
+    # Check frame indices
+    frames = output.keypoints[:, 0]
+    assert frames.min() == 0
+    assert frames.max() == T - 1
+
+
+def test_progress_emitted(track_worker_inputs):
+    worker = TrackingWorker()
+
+    progress_events = []
+    worker.progress.connect(lambda tpl: progress_events.append(tuple(tpl)))
+    worker.track(track_worker_inputs)
+
+    T = track_worker_inputs.video.shape[0]
+    assert len(progress_events) >= T  # at least one per frame
+    assert progress_events[-1] == (T - 1, T)  # final progress emit is done elsewhere
+
+
+def test_stop_tracking_emits_stopped(qtbot, track_worker_inputs):
+    worker = TrackingWorker()
+    await_stopped = qtbot.waitSignal(worker.trackingStopped, timeout=1000)
+
+    def stop_on_first_progress(tpl):
+        worker.stop_tracking()
+
+    worker.progress.connect(stop_on_first_progress)
+    worker.track(track_worker_inputs)
+    assert await_stopped.signal_triggered
+
+
+def test_unknown_tracker_emits_stopped(qtbot, track_worker_inputs):
+    worker = TrackingWorker()
+    inval_cfg = track_worker_inputs
+    inval_cfg.tracker_name = "DoesNotExist"
+    await_stopped = qtbot.waitSignal(worker.trackingStopped, timeout=1000)
+    worker.track(inval_cfg)
+    assert await_stopped.signal_triggered

--- a/src/napari_deeplabcut/tracking/_data.py
+++ b/src/napari_deeplabcut/tracking/_data.py
@@ -1,0 +1,49 @@
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+
+@dataclass
+class TrackingWorkerData:
+    tracker_name: str  # model name
+    video: np.ndarray
+    keypoints: np.ndarray  # (num_keypoint, 3)
+    # [0]: frame number in `video` [1]: x, [2]: y
+    keypoint_features: dict
+    keypoint_range: tuple[int, int]
+    backward_tracking: bool
+
+
+@dataclass(frozen=True)
+class TrackingModelInputs:
+    """Inputs required for tracking model processing."""
+
+    video: np.ndarray  # (num_frames, height, width, channels)
+    keypoints: np.ndarray  # base on model requirements
+    metadata: dict[str, Any]  # Additional metadata if needed
+
+
+@dataclass
+class RawModelOutputs:
+    """Outputs from tracking model processing."""
+
+    keypoints: np.ndarray  # (num_frames, num_keypoints, 2)
+    keypoint_features: dict[str, Any]  # Additional features if needed
+
+
+@dataclass(frozen=True)
+class TrackingWorkerOutput:
+    """
+    Returned by models and passed on to the plugin by the worker.
+
+    keypoints: (N, 3)
+        [:, 0] = frame index (int)
+        [:, 1] = x coordinate (float)
+        [:, 2] = y coordinate (float)
+    keypoint_features: dict
+        Per-keypoint/track metadata. May contain e.g. visibility scores.
+    """
+
+    keypoints: np.ndarray
+    keypoint_features: dict[str, Any]

--- a/src/napari_deeplabcut/tracking/_models.py
+++ b/src/napari_deeplabcut/tracking/_models.py
@@ -1,0 +1,236 @@
+import logging
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+import pandas as pd
+
+from napari_deeplabcut.tracking._data import (
+    RawModelOutputs,
+    TrackingModelInputs,
+    TrackingWorkerData,
+    TrackingWorkerOutput,
+)
+
+if TYPE_CHECKING:
+    from napari_deeplabcut.tracking._data import TrackingModel
+
+# List of available tracking models.
+# Automatically populated via the @register_backbone decorator.
+AVAILABLE_TRACKERS: dict[str, dict[str, Any]] = {}
+
+
+logger = logging.getLogger(__name__)
+
+
+def register_backbone(model_name: str):
+    def decorator(cls):
+        AVAILABLE_TRACKERS[model_name] = {
+            "class": cls,
+        }
+        return cls
+
+    return decorator
+
+
+class TrackingModel(ABC):
+    """Abstract base class for tracking models.
+    Use this to add new tracking models.
+    """
+
+    # These fields must be set per model
+    name: str
+    info_text: str
+
+    def __init__(self, cfg: "TrackingWorkerData"):
+        super().__init__()
+        self.cfg: TrackingWorkerData = cfg
+        if not isinstance(cfg, TrackingWorkerData):
+            raise ValueError("cfg must be an instance of TrackingWorkerData")
+
+        self.device = self.auto_set_device()
+        self.model = self.load_model(self.device)
+
+    def auto_set_device(self):
+        """Automatically set the device for the model.
+        Override this method if you have specific device requirements.
+        """
+        import torch
+
+        # check for MPS
+        if torch.backends.mps.is_available() and torch.backends.mps.is_built():
+            self.device = "mps"
+        elif torch.cuda.is_available():
+            self.device = "cuda"
+        else:
+            self.device = "cpu"
+        return self.device
+
+    @abstractmethod
+    def load_model(self, device: str) -> Any:
+        """Load the model on the specified device.
+        Make sure to use proper device and set to eval mode.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def prepare_inputs(self, cfg: "TrackingWorkerData", **kwargs) -> TrackingModelInputs:
+        """Prepare inputs for processing."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def run(self, inputs: TrackingModelInputs, progress_callback, stop_callback, **kwargs) -> RawModelOutputs:
+        """Process the inputs and return outputs."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def prepare_outputs(
+        self, model_outputs: RawModelOutputs, worker_inputs: "TrackingWorkerData" = None, **kwargs
+    ) -> "TrackingWorkerOutput":
+        """Prepare outputs after processing."""
+        raise NotImplementedError
+
+    def validate_outputs(self, inputs: TrackingModelInputs, outputs: "TrackingWorkerOutput") -> tuple[bool, str]:
+        """Validate the outputs."""
+        if not isinstance(outputs.keypoints, np.ndarray):
+            return False, "Outputs keypoints is not a numpy array."
+        if not outputs.keypoints.ndim == 2:
+            return False, "Outputs keypoints is not a 2D array."
+        if not outputs.keypoints.shape[1] == 3:
+            return False, "Outputs keypoints does not have 3 columns."
+        if not outputs.keypoints.shape[0] == inputs.keypoints.shape[0]:
+            return False, "Number of output keypoints does not match number of input keypoints."
+        return True, ""
+
+
+ct3 = "Cotracker 3"
+
+
+@register_backbone(ct3)
+class Cotracker3(TrackingModel):
+    name = ct3
+    info_text = (
+        "Cotracker 3 model from Facebook Research.\n"
+        "See https://cotracker3.github.io/ and CoTracker3: "
+        "Simpler and Better Point Tracking by "
+        "Pseudo-Labelling Real Videos by Karaev et al., 2024."
+    )
+
+    def __init__(self, cfg):
+        super().__init__(cfg)
+
+    def load_model(self, device: str):
+        import torch
+
+        model = torch.hub.load(
+            "facebookresearch/co-tracker",
+            "cotracker3_online",
+        ).to(device)
+        model.eval()
+        return model
+
+    def prepare_inputs(self, cfg: "TrackingWorkerData", **kwargs):
+        self.cfg = cfg
+        # video is originally of shape (num_frames, height, width, channels)
+        video = np.array(self.cfg.video)
+
+        # We need to swap x, y so that it matches what cotracker expects
+        self.cfg.keypoints[:, [1, 2]] = self.cfg.keypoints[:, [2, 1]]
+        queries = np.asarray(self.cfg.keypoints)
+        metadata = {
+            "keypoint_range": self.cfg.keypoint_range,
+            "backward_tracking": self.cfg.backward_tracking,
+        }
+        return TrackingModelInputs(
+            video=video,
+            keypoints=queries,
+            metadata=metadata,
+        )
+
+    def run(self, inputs: TrackingModelInputs, progress_callback, stop_callback) -> RawModelOutputs:
+        import torch
+
+        video = torch.from_numpy(inputs.video).to(self.device).float()
+        queries = torch.from_numpy(inputs.keypoints).to(self.device).float()
+
+        window_frames = []
+        is_first_step = True
+        for i, frame in enumerate(video):
+            if i % self.model.step == 0 and i != 0:
+                pred_tracks, _pred_visibility = self._process_step(window_frames, is_first_step, queries=queries)
+                is_first_step = False
+            window_frames.append(frame)
+            progress_callback(i, len(video))
+            if stop_callback():
+                logger.debug("Tracking stopped.")
+                return
+
+        pred_tracks, _pred_visibility = self._process_step(
+            window_frames[-(i % self.model.step) - self.model.step - 1 :],
+            is_first_step,
+            queries=queries,
+        )
+        progress_callback(len(video), len(video))
+
+        tracks = pred_tracks.squeeze().cpu().numpy()
+        _pred_visibility = _pred_visibility.squeeze().cpu().numpy()  #
+
+        return RawModelOutputs(
+            keypoints=tracks,
+            keypoint_features={"visibility": _pred_visibility},
+        )
+
+    def prepare_outputs(
+        self, model_outputs: RawModelOutputs, worker_inputs: TrackingWorkerData = None, **kwargs
+    ) -> "TrackingWorkerOutput":
+        """
+        Convert raw outputs into canonical format:
+        - Flatten tracks into (N, 3): [frame_idx, x, y]
+        - Restore original x/y order for worker.
+        """
+        tracks = model_outputs.keypoints  # shape: (T, K, 2)
+        T1, T2 = worker_inputs.keypoint_range
+        K = worker_inputs.keypoints.shape[0]
+
+        # Flatten and add frame indices
+        frame_ids = np.repeat(np.arange(T1, T2), K)
+        tracks = tracks.reshape(-1, 2)
+
+        # If backward tracking requested
+        if worker_inputs.backward_tracking:
+            tracks = tracks[::-1]
+        # Combine into (N, 3)
+        keypoints = np.column_stack((frame_ids, tracks))
+
+        keypoints_features = model_outputs.keypoint_features
+        keypoints_features = pd.concat(
+            [worker_inputs.keypoint_features] * len(np.unique(keypoints[:, 0])),
+            ignore_index=True,
+        )
+
+        # Restore original x/y order
+        keypoints[:, [1, 2]] = keypoints[:, [2, 1]]
+
+        return TrackingWorkerOutput(
+            keypoints=keypoints,
+            keypoint_features=keypoints_features,
+        )
+
+    def _process_step(self, window_frames, is_first_step, queries):
+        """
+        Internal helper for chunked processing.
+        """
+        import torch
+
+        video_chunk = (
+            torch.tensor(np.stack(window_frames[-self.model.step * 2 :]), device=self.device)
+            .float()
+            .permute(0, 3, 1, 2)[None]
+        )  # (1, T, 3, H, W)
+        # logger.debug(f"Video chunk shape: {video_chunk.shape}, Queries shape: {queries.shape}")
+        return self.model(
+            video_chunk,
+            is_first_step=is_first_step,
+            queries=queries[None],
+            add_support_grid=True,
+        )

--- a/src/napari_deeplabcut/tracking/_widgets.py
+++ b/src/napari_deeplabcut/tracking/_widgets.py
@@ -28,12 +28,9 @@ from qtpy.QtWidgets import (
 )
 
 from napari_deeplabcut.keypoints import KeypointStore
-from napari_deeplabcut.tracking._worker import (
-    TrackerInfo,
-    TrackerType,
-    TrackingWorker,
-    TrackingWorkerData,
-)
+from napari_deeplabcut.tracking._data import TrackingWorkerData, TrackingWorkerOutput
+from napari_deeplabcut.tracking._models import AVAILABLE_TRACKERS
+from napari_deeplabcut.tracking._worker import TrackingWorker
 
 # Keybinds
 TRACKING_SHORTCUTS_ENABLED = os.environ.get("NAPARI_DLC_TRACKING_SHORTCUTS_ENABLED", "1") == "1"
@@ -149,9 +146,10 @@ class TrackingControls(QWidget):
 
     def _set_model_info_tooltip(self, current_model_name: str = None):
         """Retrieves the display info for the selected model and sets it as tooltip for the model info button."""
-        tracker_info = TrackerInfo.get_info_from_name(current_model_name)
-        if tracker_info is not None and tracker_info.info_text:
-            self._model_info_button.setToolTip(tracker_info.info_text)
+        tracker_info = AVAILABLE_TRACKERS.get(current_model_name, None)
+        tracker_info = tracker_info["class"].info_text if tracker_info is not None else None
+        if tracker_info is not None:
+            self._model_info_button.setToolTip(tracker_info)
         else:
             self._model_info_button.setToolTip("")
 
@@ -368,11 +366,20 @@ class TrackingControls(QWidget):
         self.is_tracking = True
         self._tracking_progress_bar.setValue(0)
 
-    @Slot(TrackingWorkerData)
-    def tracking_finished(self, trackingdata: TrackingWorkerData):
+    @Slot(TrackingWorkerOutput)
+    def tracking_finished(self, out: TrackingWorkerOutput):
         self.is_tracking = False
         try:
-            self.add_keypoints_to_layer(trackingdata.keypoints, trackingdata.keypoint_features)
+            try:
+                new_features_df = (
+                    out.keypoint_features
+                    if isinstance(out.keypoint_features, pd.DataFrame)
+                    else pd.DataFrame(out.keypoint_features)
+                )
+            except ValueError as e:
+                logger.error(f"Failed to convert keypoint features to DataFrame: {e}")
+                new_features_df = pd.DataFrame()
+            self.add_keypoints_to_layer(out.keypoints, new_features_df)
         except Exception as e:
             print(e)
         self._tracking_progress_bar.setValue(self._tracking_progress_bar.maximum())
@@ -494,7 +501,7 @@ class TrackingControls(QWidget):
         keypoints[:, 0] = 0
         keypoint_features = self.keypoint_layer.features[self.keypoint_layer.data[:, 0] == ref_frame_idx]
         tracking_data = TrackingWorkerData(
-            tracker=TrackerType.get_from_name(self._tracking_method_combo.currentText()),
+            tracker_name=self._tracking_method_combo.currentText(),  # do not instantiate yet
             video=video_slice,
             keypoints=keypoints,
             keypoint_features=keypoint_features,
@@ -508,7 +515,7 @@ class TrackingControls(QWidget):
         self.setLayout(QVBoxLayout())
         # self._tracking_method_combo.addItems(["Cotracker", "PIP"])
         ## Model selection
-        self._tracking_method_combo.addItems(TrackerType.get_all_names())
+        self._tracking_method_combo.addItems(AVAILABLE_TRACKERS.keys())
         # self._tracking_method_combo.setCurrentText("Cotracker")
         self._tracking_method_combo.setCurrentIndex(0)
 

--- a/src/napari_deeplabcut/tracking/_widgets.py
+++ b/src/napari_deeplabcut/tracking/_widgets.py
@@ -478,6 +478,13 @@ class TrackingControls(QWidget):
 
     @Slot()
     def track_bothway(self):
+        # if forward target is invalid, go directly backward
+        ref = self._reference_spinbox.value()
+        fwd = self._forward_spinbox_absolute.value()
+        if fwd <= ref:
+            self.track_backward()
+            return
+
         self.track_forward()
         self.trackedKeypointsAdded.connect(self.track_backward, type=Qt.ConnectionType.SingleShotConnection)
 

--- a/src/napari_deeplabcut/tracking/_worker.py
+++ b/src/napari_deeplabcut/tracking/_worker.py
@@ -52,6 +52,7 @@ class TrackingWorker(QObject):
             4. prepare_outputs(raw, inputs)
             5. Emit results to the plugin.
         """
+        model = None
         try:
             # Choose model by name from your TrackerType (cfg.tracker.value.name)
             # if DEBUG:
@@ -103,7 +104,8 @@ class TrackingWorker(QObject):
             self.trackingFinished.emit(output)
         finally:
             torch.cuda.empty_cache()
-            del model
+            if model is not None:
+                del model
 
     def run(self):
         self.started.emit()

--- a/src/napari_deeplabcut/tracking/_worker.py
+++ b/src/napari_deeplabcut/tracking/_worker.py
@@ -1,17 +1,27 @@
-import enum
 import logging
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
-import numpy as np
-import pandas as pd
+import torch
 from qtpy.QtCore import QCoreApplication, QObject, QThread, Signal, Slot
+
+from napari_deeplabcut.tracking._data import (
+    RawModelOutputs,
+    TrackingModelInputs,
+    TrackingWorkerData,
+    TrackingWorkerOutput,
+)
+from napari_deeplabcut.tracking._models import AVAILABLE_TRACKERS
+
+if TYPE_CHECKING:
+    pass
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 DEBUG = True
 if DEBUG:
-    import debugpy
+    pass
 
 
 @dataclass
@@ -20,161 +30,80 @@ class TorchHubModel:
     model: str
 
 
-@dataclass(frozen=True)
-class TrackerInfo:
-    name: str
-    torchhub: TorchHubModel
-    info_text: str = ""
-
-    def load_model(self, device: str):
-        import torch
-
-        model = torch.hub.load(
-            self.torchhub.org,
-            self.torchhub.model,
-        ).to(device)
-        return model
-
-    @staticmethod
-    def get_info_from_name(name: str) -> "TrackerInfo | None":
-        """Get the TrackerInfo dataclass from its name."""
-        if name is not None:
-            for tracker in TrackerType:
-                if tracker.value.name == name:
-                    return tracker.value
-        return None
-
-
-class TrackerType(enum.Enum):
-    COTRACKER = TrackerInfo(
-        name="Cotracker 3",
-        torchhub=TorchHubModel(
-            org="facebookresearch/co-tracker",
-            model="cotracker3_online",
-        ),
-        info_text="Cotracker 3 model from Facebook Research.\n"
-        "See https://cotracker3.github.io/ and CoTracker3: "
-        "Simpler and Better Point Tracking by "
-        "Pseudo-Labelling Real Videos by Karaev et al., 2024.",
-    )
-
-    def get_all_names() -> list[str]:
-        """Get a list of all implemented tracker names."""
-        return [tracker.value.name for tracker in TrackerType]
-
-    def get_from_name(name: str) -> "TrackerType | None":
-        """Get the TrackerType enum member from its name."""
-        for tracker in TrackerType:
-            if tracker.value.name == name:
-                return tracker
-        return None
-
-
-@dataclass
-class TrackingWorkerData:
-    tracker: TrackerType
-    video: np.ndarray
-    keypoints: np.ndarray  # (num_keypoint, 3)
-    # [0]: frame number in `video` [1]: x, [2]: y
-    keypoint_features: dict
-    keypoint_range: tuple[int, int]
-    backward_tracking: bool
-
-
 class TrackingWorker(QObject):
     started = Signal()
     finished = Signal()
     progress = Signal(tuple)
     trackingStarted = Signal()
-    trackingFinished = Signal(TrackingWorkerData)
+    trackingFinished = Signal(TrackingWorkerOutput)
     trackingStopped = Signal()
 
     def __init__(self):
         super().__init__()
-        import torch
-
         self.is_stopped = False
-        self.device = "cuda" if torch.cuda.is_available() else "cpu"  # TODO implement MPS support
-        self.model: object | None = None
 
     @Slot(TrackingWorkerData)
     def track(self, cfg: TrackingWorkerData):
-        if DEBUG:
-            debugpy.debug_this_thread()
-        import torch
-
-        if self.model is None:
-            self.model = cfg.tracker.value.load_model(self.device)
-            self.model.eval()
-
-        def _process_step(window_frames, is_first_step, queries):
-            # NOTE ideally each model should have its own processing
-            # function implemented separately and return the same format
-            video_chunk = (
-                torch.tensor(np.stack(window_frames[-self.model.step * 2 :]), device=self.device)
-                .float()
-                .permute(0, 3, 1, 2)[None]
-            )  # (1, T, 3, H, W)
-            logger.debug(f"Video chunk shape: {video_chunk.shape},Queries shape: {queries.shape}")
-            return self.model(
-                video_chunk,
-                is_first_step=is_first_step,
-                queries=queries[None],
-                add_support_grid=True,
-            )
-
-        # video is originally of shape (num_frames, height, width, channels)
-        video = np.array(cfg.video)
-        window_frames = []
-
-        # We need to swap x, y so that it matches what cotracker expects
-        cfg.keypoints[:, [1, 2]] = cfg.keypoints[:, [2, 1]]
-
-        queries = torch.from_numpy(cfg.keypoints).to(self.device).float()
-
-        # Iterating over video frames, processing one window at a time:
-        is_first_step = True
-        for i, frame in enumerate(video):
-            if i % self.model.step == 0 and i != 0:
-                pred_tracks, _pred_visibility = _process_step(window_frames, is_first_step, queries=queries)
-                is_first_step = False
-            window_frames.append(frame)
-            self.progress.emit((i, len(video)))
-            if self._should_stop():
+        """
+        Tracking core logic:
+            1. Instantiate model from registry.
+            2. prepare_inputs(cfg)
+            3. run(inputs, progress_cb, stop_cb)
+            4. prepare_outputs(raw, inputs)
+            5. Emit results to the plugin.
+        """
+        try:
+            # Choose model by name from your TrackerType (cfg.tracker.value.name)
+            # if DEBUG:
+            #     debugpy.debug_this_thread()
+            model_name = cfg.tracker_name
+            try:
+                model_cls = AVAILABLE_TRACKERS[model_name]["class"]
+            except KeyError:
+                logger.error(f"Unknown tracker: {model_name}")
+                self.trackingStopped.emit()
                 return
 
-        # Processing final frames in case video length is not a multiple of model.step
-        # TODO: Use visibility
-        logger.debug(f"Window frames shape before final processing:{np.array(window_frames).shape}")
-        pred_tracks, _pred_visibility = _process_step(
-            window_frames[-(i % self.model.step) - self.model.step - 1 :],
-            is_first_step,
-            queries=queries,
-        )
-        if DEBUG and pred_tracks is None:
-            debugpy.breakpoint()
-        logger.debug(f"Predicted tracks : {pred_tracks}")
-        logger.debug(f"Predicted visibility: {_pred_visibility}")
-        self.progress.emit((len(video), len(video)))
+            model = model_cls(cfg)
 
-        tracks = pred_tracks.squeeze().cpu().numpy()
-        # drop the support grid (necessary only for cotracker version < 3)
-        # as we are using ct3, we skip dropping the support grid
-        # tracks = tracks[:, :cfg.keypoints.shape[0], :]
-        tracks = tracks.reshape(-1, 2)
-        if cfg.backward_tracking:
-            tracks = tracks[::-1]
-        frame_ids = np.repeat(
-            np.arange(cfg.keypoint_range[0], cfg.keypoint_range[1]),
-            cfg.keypoints.shape[0],
-        )
-        tracks = np.column_stack((frame_ids, tracks))
-        cfg.keypoint_features = pd.concat([cfg.keypoint_features] * len(np.unique(tracks[:, 0])), ignore_index=True)
-        cfg.keypoints = tracks
-        cfg.keypoints[:, [1, 2]] = cfg.keypoints[:, [2, 1]]
-        self.trackingFinished.emit(cfg)
+            # Define callbacks to let the model report status
+            def progress_callback(current: int, total: int):
+                self.progress.emit((current, total))
 
-        # self.model = None  # free up memory ?
+            def stop_callback() -> bool:
+                # Return early if requested
+                return self._should_stop()
+
+            try:
+                # we let the model handle coordinate conventions internally, such that
+                # the worker and plugin can remain agnostic to these details.
+                inputs: TrackingModelInputs = model.prepare_inputs(cfg)
+
+                # Run inference; models implement their own batching and chunking
+                raw: RawModelOutputs = model.run(inputs, progress_callback, stop_callback)
+
+                # Convert to canonical output (N,3) plus features
+                output: TrackingWorkerOutput = model.prepare_outputs(raw, cfg)
+
+                if hasattr(model, "validate_outputs") and not model.validate_outputs(inputs, output):
+                    valid, msg = model.validate_outputs(inputs, output)
+                    if not valid:
+                        raise ValueError(f"Invalid model outputs: {msg}")
+            except Exception as exc:
+                logger.exception("Tracking failed", exc_info=exc)
+                self.trackingStopped.emit()
+                return
+
+            # Old : update the worker cfg & keep existing signal type
+            # cfg.keypoints = output.keypoints
+            # cfg.keypoint_features = output.keypoint_features
+            # self.trackingFinished.emit(cfg)
+
+            # Use the new signal type only and keep cfg immutable
+            self.trackingFinished.emit(output)
+        finally:
+            torch.cuda.empty_cache()
+            del model
 
     def run(self):
         self.started.emit()


### PR DESCRIPTION
This pull request introduces a new, extensible tracking model framework, including a standardized data interface, an abstract base class for tracking models, and a registry for available trackers. 
It also adds a minimal dummy tracker for testing, comprehensive tests for tracking widgets and worker logic, and refactors the codebase to use the new system. 

**Core tracking model framework and data structures:**

* Introduced new data classes in `tracking/_data.py` to standardize the interface between tracking models, workers, and outputs (`TrackingWorkerData`, `TrackingModelInputs`, `RawModelOutputs`, `TrackingWorkerOutput`).
* Added `tracking/_models.py` with an abstract base class `TrackingModel`, a registry for available trackers (`AVAILABLE_TRACKERS`), a decorator for registering new trackers, and an initial implementation for the Cotracker 3 model.

**Testing infrastructure and dummy tracker:**

* Added a minimal `DummyTracker` implementation in the test fixtures, which is auto-registered for tests, and a fixture to provide minimal valid tracking data for worker tests.
* Updated test imports and fixtures to use the new data/model interfaces.

**Comprehensive tracking tests:**

* Added new tests for the tracking worker (`test_worker.py`) covering output structure, progress reporting, stop functionality, and error handling for unknown trackers.
* Added new tests for the tracking widget UI logic (`test_widgets.py`), including layer selection, frame range logic, and tracking requests for forward, backward, and both-way tracking.

Current coverage:
```
Name                                                    Stmts   Miss Branch BrPart  Cover
-----------------------------------------------------------------------------------------
src\napari_deeplabcut\__init__.py                          13      2      0      0    85%
src\napari_deeplabcut\_reader.py                          186     26     54      8    85%
src\napari_deeplabcut\_tests\__init__.py                    0      0      0      0   100%
src\napari_deeplabcut\_tests\conftest.py                  118      4     10      1    95%
src\napari_deeplabcut\_tests\test_keypoints.py             57      0      0      0   100%
src\napari_deeplabcut\_tests\test_misc.py                  87      0      0      0   100%
src\napari_deeplabcut\_tests\test_reader.py                75      0      0      0   100%
src\napari_deeplabcut\_tests\test_widgets.py               90      0      0      0   100%
src\napari_deeplabcut\_tests\tracking\test_widgets.py     123      1      8      1    98%
src\napari_deeplabcut\_tests\tracking\test_worker.py       37      0      0      0   100%
src\napari_deeplabcut\_version.py                          13      0      0      0   100%
src\napari_deeplabcut\_widgets.py                        1063    300    276     34    68%
src\napari_deeplabcut\_writer.py                           88     39     16      3    50%
src\napari_deeplabcut\keypoints.py                        149     27     30      6    75%
src\napari_deeplabcut\misc.py                             132     14     22      4    88%
src\napari_deeplabcut\tracking\_data.py                    24      0      0      0   100%
src\napari_deeplabcut\tracking\_models.py                 109     55     22      6    47%
src\napari_deeplabcut\tracking\_widgets.py                378     76     44      8    78%
src\napari_deeplabcut\tracking\_worker.py                  77     14     10      2    79%
-----------------------------------------------------------------------------------------
TOTAL                                                    2819    558    492     73    77%
```

**Codebase refactoring:**

* Updated `tracking/_widgets.py` to use the new data/model interfaces and tracker registry, removing old imports and adapting to the new structure.